### PR TITLE
fix: Add Ably-specific usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ const realtime = new Ably.Realtime({
 });
 
 const channel = realtime.channels.get('your-ably-channel', {
-    delta: 'vcdiff'
-})
+    params: {
+        delta: 'vcdiff'
+    }
+});
 
 channel.subscribe(msg => console.log("Received message: ", msg));
 ```


### PR DESCRIPTION
## Description

The usage example given was not Ably-specific. This PR updates the usage example to show how this version of Vcdiff would be used with Ably.

Also, a slight renaming of the `const` variable name to match the usage example, and make it clear when specifying the plugin what is the plugin keyname and value name:

```
 plugins: {
        vcdiff: vcdiffPlugin
}
```

The idea is that [this page](https://www.npmjs.com/package/@ably/vcdiff-decoder) would be updated.
