### PR TITLE
Add TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "homepage": "https://ably.io/",
   "main": "lib/vcdiff_decoder.js",
+  "typings": "typings.d.ts",
   "scripts": {
     "grunt": "grunt",
     "test": "grunt test:all"
@@ -28,7 +29,8 @@
   },
   "files": [
     "lib",
-    "dist"
+    "dist",
+    "typings.d.ts"
   ],
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,1 @@
+export declare function decode(delta: Uint8Array, source: Uint8Array): Uint8Array;


### PR DESCRIPTION
So that users importing it in TypeScript don’t get an error like this:

> Could not find a declaration file for module '@ably/vcdiff-decoder'. '/Users/lawrence/code/work/ably/ably-js/node_modules/@ably/vcdiff-decoder/lib/vcdiff_decoder.js' implicitly has an 'any' type.